### PR TITLE
Clarify getBundleStats

### DIFF
--- a/docs/flashbots-auction/searchers/advanced/rpc-endpoint.mdx
+++ b/docs/flashbots-auction/searchers/advanced/rpc-endpoint.mdx
@@ -247,7 +247,7 @@ The `flashbots_getBundleStats` JSON-RPC method returns stats for a single bundle
   "params": [
     {
       bundleHash,       // String, returned by the flashbots api when calling eth_sendBundle
-      blockNumber,       // String, a hex encoded block number
+      blockNumber,       // String, the block number the bundle was targeting 
     }
   ]
 }

--- a/docs/flashbots-auction/searchers/advanced/rpc-endpoint.mdx
+++ b/docs/flashbots-auction/searchers/advanced/rpc-endpoint.mdx
@@ -247,7 +247,7 @@ The `flashbots_getBundleStats` JSON-RPC method returns stats for a single bundle
   "params": [
     {
       bundleHash,       // String, returned by the flashbots api when calling eth_sendBundle
-      blockNumber,       // String, the block number the bundle was targeting 
+      blockNumber,       // String, the block number the bundle was targeting (hex encoded)
     }
   ]
 }


### PR DESCRIPTION
The current docs are not very clear for flashbots_getBundleStats method and doesnt communicate that it should be the same as the targeted block.