### PR TITLE
fix broken & missing alchemy links

### DIFF
--- a/docs/flashbots-auction/searchers/advanced/rpc-endpoint.mdx
+++ b/docs/flashbots-auction/searchers/advanced/rpc-endpoint.mdx
@@ -144,7 +144,7 @@ example response:
 
 `eth_sendPrivateTransaction` is used to send a single transaction to Flashbots. Flashbots will attempt to send the transaction to miners for the next 25 blocks. See [Private Transactions](/flashbots-auction/searchers/advanced/private-transaction.mdx) for more info.
 
-[`eth_sendPrivateTransaction`](https://docs.alchemy.com/alchemy/apis/ethereum/eth-sendPrivateTransaction/?a=fb) is also supported for free on [Alchemy](https://alchemy.com/?a=fb).
+[`eth_sendPrivateTransaction`](https://docs.alchemy.com/reference/eth-sendprivatetransaction?a=fb) is also supported for free on [Alchemy](https://alchemy.com?a=fb).
 
 This method has the following JSON-RPC format:
 
@@ -191,6 +191,8 @@ example response:
 ### eth_cancelPrivateTransaction
 
 The `eth_cancelPrivateTransaction` method stops private transactions from being submitted for future blocks. A transaction can only be cancelled if the request is signed by the same key as the `eth_sendPrivateTransaction` call submitting the transaction in first place.
+
+[`eth_cancelPrivateTransaction`](https://docs.alchemy.com/reference/eth-cancelprivatetransaction?a=fb) is also supported for free on [Alchemy](https://alchemy.com?a=fb).
 
 This method has the following JSON-RPC format:
 

--- a/docs/flashbots-auction/searchers/quick-start.mdx
+++ b/docs/flashbots-auction/searchers/quick-start.mdx
@@ -27,7 +27,7 @@ To access the Flashbots network you will need three things:
 
 1. A private key that Flashbots can use to identify you
 2. A way to interact with the Flashbots network
-   - [Alchemy](https://docs.alchemy.com/alchemy/apis/ethereum/eth-sendPrivateTransaction/?a=fb) offers an easy way to send single transactions to Flashbots
+   - [Alchemy](https://docs.alchemy.com/docs/how-to-send-a-private-transaction-on-ethereum?a=fb) offers an easy way to send single transactions to Flashbots.
 3. A "bundle" for your transactions
 
 Let's begin with the private key Flashbots uses for identity. When you send bundles to Flashbots you will sign them with a private key so that we can establish identity for searchers and establish reputation for them over time. This private key **does not** store funds and is **not** the primary private key you use for executing transactions. Again, it is only used for identity, and it can be any private key.


### PR DESCRIPTION
Alchemy revamped their docs and broke the links we had here in our docs. This fixes them, and adds a link to their `eth_cancelPrivateTransaction` page, which was missing before.