### PR TITLE
Updating the documentation to reflect Alchemy's SDK

### DIFF
--- a/docs/flashbots-auction/searchers/libraries/alchemyprovider.md
+++ b/docs/flashbots-auction/searchers/libraries/alchemyprovider.md
@@ -1,0 +1,21 @@
+---
+title: alchemy provider
+---
+The Alchemy SDK  makes getting started, shipping builds, and accessing support faster and more streamlined. For instance, it provides high-level access to the `eth_sendPrivateTransaction` and `eth_cancelPrivateTransaction` rpc endpoints on mev-relay.
+
+Benefits of the Alchemy SDK include providing:
+
+**1. Automatic management of your Flashbots reputation** - 
+the SDK takes on the work of actively, and manually, managing your reputation. Learn more about reputation [here](https://docs.flashbots.net/flashbots-auction/searchers/advanced/reputation#querying-reputation)
+
+**2. A superset of the ethers.js Provider library plus the suite of Alchemy APIs** - the Alchemy Provider exposes the relay endpoints and makes the full JSON-RPC specification endpoints available. The Flashbots relay API can be used natively with the core EVM APIs as well as the suite of Alchemy APIs
+
+**3. Webhook based notifications on [mined and dropped private transactions](https://docs.alchemy.com/docs/alchemy-notify#features)**
+
+To get started:
+
+* [https://www.alchemy.com/sdk](https://www.alchemy.com/sdk)
+
+* [https://docs.alchemy.com/reference/eth-sendprivatetransaction](https://docs.alchemy.com/reference/eth-sendprivatetransaction)
+
+* [https://github.com/alchemyplatform/alchemy-sdk-js](https://github.com/alchemyplatform/alchemy-sdk-js)

--- a/docs/flashbots-auction/searchers/libraries/golang.md
+++ b/docs/flashbots-auction/searchers/libraries/golang.md
@@ -9,5 +9,6 @@ Flashbots-enabled relays and miners expose several new jsonrpc endpoints, such a
 
 Golang libraries:
 
+* [https://github.com/alchemyplatform/alchemy-sdk-js](https://github.com/alchemyplatform/alchemy-sdk-js)
 * [github.com/metachris/flashbotsrpc](https://github.com/metachris/flashbotsrpc)
 * [github.com/cryptoriums/flashbot](https://github.com/cryptoriums/flashbot)


### PR DESCRIPTION
Per the convo with Flashbots, adding alchemy-sdk as a library here :) One of the features we have is that we have reputation management on the backened instead of having searches manage a secondary address to manage their reputation. Let me know if you have any questions, thanks so much! 