### PR TITLE
Adding SDK library

### DIFF
--- a/docs/flashbots-auction/searchers/libraries/golang.md
+++ b/docs/flashbots-auction/searchers/libraries/golang.md
@@ -9,6 +9,5 @@ Flashbots-enabled relays and miners expose several new jsonrpc endpoints, such a
 
 Golang libraries:
 
-* [https://github.com/alchemyplatform/alchemy-sdk-js](https://github.com/alchemyplatform/alchemy-sdk-js)
 * [github.com/metachris/flashbotsrpc](https://github.com/metachris/flashbotsrpc)
 * [github.com/cryptoriums/flashbot](https://github.com/cryptoriums/flashbot)


### PR DESCRIPTION
Per our convo with Flashbots, adding alchemy-sdk (which is a superset of the ethers.js Provider library) as a file here to help get developers up and running on your awesome features! Pls lmk if you have any questions, thanks :)