### PR TITLE
Add Dockerfile and docker-compose definitions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:16.17-alpine
+
+WORKDIR /flashbots-docs
+
+COPY package*.json .
+COPY yarn.lock .
+
+RUN yarn install
+
+COPY . .
+
+EXPOSE 3000
+CMD ["yarn", "start", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Website
 
-This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator. 
+[The Flashbots Docs website](https://docs.flashbots.net/) is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
 
-## Installation
+## Getting Started
 
-First create a copy of the environment file `.env.template` in the root of the codebase and rename it to `.env`
+First create a copy of the environment file `.env.template` in the root of the codebase and rename it to `.env`.
+You can either install the dependencies on your local environment using `yarn` or run the project using `docker compose`
+
+## Local Environment
+
+### Installation
 
 Then run the following:
 
@@ -12,7 +17,7 @@ Then run the following:
 yarn install
 ```
 
-## Local Development
+### Local Development
 
 ```console
 yarn start
@@ -20,13 +25,21 @@ yarn start
 
 This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
 
-## Build
+### Build
 
 ```console
 yarn build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
+
+## Docker compose
+
+```console
+docker compose up
+```
+
+This command builds and runs the container mounting the project code.
 
 ## Deployment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+---
+version: "3.9"
+services:
+  web:
+    build: .
+    volumes:
+      - .:/flashbots-docs
+      - /flashbots-docs/node_modules
+    ports:
+      - 3000:3000


### PR DESCRIPTION
Add `Dockerfile` and `docker-compose` definitions to avoid installing packages in a local environment. The Dockerfile is not meant for a production environment and should be used only for development purposes.

Update `README` reflecting these changes.
