### PR TITLE
Updating list of community tools

### DIFF
--- a/docs/community-tools.mdx
+++ b/docs/community-tools.mdx
@@ -1,5 +1,5 @@
 ---
-title: community tools
+title: Community tools
 ---
 
 ### [Flashbots Bundle Explorer](http://flashbots-explorer.marto.lol/)
@@ -8,10 +8,22 @@ title: community tools
 - Search by block number
 - Shareable permalinks (e.g. https://flashbots-explorer.marto.lol/?block=12506647)
 
-[![Flashbots Bundle Explorer](/img/bundle-explorer.png)](http://flashbots-explorer.marto.lol/)
+### [Mevboost.org](https://www.mevboost.org/)
 
-### [flashbots.tools](https://flashbots.tools/)
+- Dashboard tracking the top relayers and builders of MEV-Boost.
 
-Simple frontend to interface with https://github.com/flashbots
+### [MEV-Boost Dashboard](https://dune.com/ChainsightAnalytics/mev-after-ethereum-merge)
 
-![Flashbots Tools](/img/flashbots-tools.png)
+- Overview of MEV-Boost adoption and profitability of proposers and block builders.
+
+### [mevboost.pics](https://mevboost.pics/)
+
+- Interactive dashboard of the MEV-Boost relay and builder markets.
+
+### [MEV Watch](https://www.mevwatch.info/)
+
+- Visualization of the number of blocks proposed by MEV-Boost relays excluding certain transactions compared to content agnostic relays. 
+
+### [Relay Monitor by Metrika](https://app.metrika.co/dashboard/ethereum/relay-monitor/north-america-east?tr=1d)
+
+- Monitor the bids, blocks and latency of MEV-Boost Relays.


### PR DESCRIPTION
Remove "flashbots.tools" -- the domain has expired. Removed print screens from Flashbots bundle explorer. Added additional tools (some of which are not really "community" built. Unsure where to draw the line)