### PR TITLE
Dark mode styles update

### DIFF
--- a/src/components/GridBlock/GridBlock.tsx
+++ b/src/components/GridBlock/GridBlock.tsx
@@ -13,7 +13,7 @@ const GridBlock = ({ children, symbol, title }: IGridBlock) => {
       <div></div>
       <div></div>
       <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M1.23804 0.5H23.5309L1.23804 22.7929V0.5Z" fill="#DBDDE1" fillOpacity="0.25" stroke="#DBDDE1"/>
+        <path d="M1.23804 0.5H23.5309L1.23804 22.7929V0.5Z" fill="#CACBCE" fill-opacity="0.15" stroke="#A8ABB2" stroke-opacity="0.3"/>
       </svg>
 
     </div>

--- a/src/components/GridBlock/GridBlock.tsx
+++ b/src/components/GridBlock/GridBlock.tsx
@@ -13,7 +13,7 @@ const GridBlock = ({ children, symbol, title }: IGridBlock) => {
       <div></div>
       <div></div>
       <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M1.23804 0.5H23.5309L1.23804 22.7929V0.5Z" fill="#CACBCE" fill-opacity="0.15" stroke="#A8ABB2" stroke-opacity="0.3"/>
+        <path d="M1.23804 0.5H23.5309L1.23804 22.7929V0.5Z" fill="#CACBCE" fillOpacity="0.15" stroke="#A8ABB2" strokeOpacity="0.3"/>
       </svg>
 
     </div>

--- a/src/components/GridBlock/styles.module.scss
+++ b/src/components/GridBlock/styles.module.scss
@@ -17,9 +17,9 @@
       left: 0;
       width: 100%;
       height: calc((100% - 25px) + 1px);
-      border-top: 1px solid rgb(219,221,225);
-      border-left: 1px solid rgb(219,221,225);
-      border-right: 1px solid rgb(219,221,225);
+      border-top: 1px solid var(--ifm-color-emphasis-200);
+      border-left: 1px solid var(--ifm-color-emphasis-200);
+      border-right: 1px solid var(--ifm-color-emphasis-200);
     }
     &:nth-child(2) {
       position: absolute;
@@ -27,8 +27,8 @@
       left: 0;
       width: calc((100% - 25px) + 1px);
       height: 25px;
-      border-bottom: 1px solid rgb(219,221,225);
-      border-left: 1px solid rgb(219,221,225);
+      border-bottom: 1px solid var(--ifm-color-emphasis-200);
+      border-left: 1px solid var(--ifm-color-emphasis-200);
     }
     &:last-child {
       position: absolute;

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -86,4 +86,6 @@ h2 {
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
 }
 
-
+.menu__link--sublist:after {
+  background: var(--ifm-menu-link-sublist-icon) 50%/1.5rem 1.5rem;
+}

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -35,13 +35,17 @@
   // --ifm-color-primary: #25c2a0;
   --ifm-color-primary: #0044FF;
   --ifm-color-content: var(--ifm-color-emphasis-800);
-  --ifm-color-primary-dark: #99AAFF;
+  // --ifm-color-primary-dark: #99AAFF;
   // --ifm-color-primary-darker: rgb(31, 165, 136);
   // --ifm-color-primary-darkest: rgb(26, 136, 112);
   // --ifm-color-primary-light: rgb(70, 203, 174);
   // --ifm-color-primary-lighter: rgb(102, 212, 189);
   // --ifm-color-primary-lightest: rgb(146, 224, 208);
   --ifm-code-font-size: 95%;
+}
+
+[data-theme='dark'] {
+  --ifm-color-primary: #99AAFF;
 }
 
 .docusaurus-highlight-code-line {

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -46,6 +46,7 @@
 
 [data-theme='dark'] {
   --ifm-color-primary: #99AAFF;
+  --ifm-heading-color: #FFFFFF;
 }
 
 .docusaurus-highlight-code-line {

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -78,7 +78,7 @@ h1, h2, h3 {
 
 h2 {
   padding-bottom: 16px;
-  border-bottom: solid 1px var(--ifm-color-gray-300);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
 }
 
 

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -35,7 +35,7 @@
   // --ifm-color-primary: #25c2a0;
   --ifm-color-primary: #0044FF;
   --ifm-color-content: var(--ifm-color-emphasis-800);
-  // --ifm-color-primary-dark: rgb(33, 175, 144);
+  --ifm-color-primary-dark: #99AAFF;
   // --ifm-color-primary-darker: rgb(31, 165, 136);
   // --ifm-color-primary-darkest: rgb(26, 136, 112);
   // --ifm-color-primary-light: rgb(70, 203, 174);
@@ -69,7 +69,7 @@
 
 h1, h2, h3, h4, h5, h6 {
   font-family: 'CMU-Serif', 'Times New Roman', Garamond, Georgia, serif;
-  color: var(--ifm-color-gray-1000);
+  // color: var(--ifm-color-gray-1000);
 }
 
 h1, h2, h3 {

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -88,4 +88,5 @@ h2 {
 
 .menu__link--sublist:after {
   background: var(--ifm-menu-link-sublist-icon) 50%/1.5rem 1.5rem;
+  opacity: .75;
 }


### PR DESCRIPTION
- Updated font and stroke colors for the dark theme.
Before/ After preview
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/11165157/211630422-0fd9f3bf-db91-48ca-8c55-878b1d179dda.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/11165157/211630359-091cb5a2-403b-4106-ae37-15c9ad045869.png">


- Make the sidebar arrows smaller and lighter
Before/ After preview:
<img width="334" alt="image" src="https://user-images.githubusercontent.com/11165157/211630113-a615681b-ce24-4ef4-b57b-78de0943f547.png"><img width="330" alt="image" src="https://user-images.githubusercontent.com/11165157/211630223-6800f7c4-929d-4288-a744-33888fb5d60d.png">

