### PR TITLE
Added ethers.js SDK

### DIFF
--- a/docs/flashbots-auction/searchers/advanced/private-transaction.mdx
+++ b/docs/flashbots-auction/searchers/advanced/private-transaction.mdx
@@ -15,7 +15,7 @@ Private transactions can be cancelled with the `eth_cancelPrivateTransaction` me
 
 See [RPC endpoint](/flashbots-auction/searchers/advanced/rpc-endpoint) for JSON-RPC definitions of the methods.
 
-These methods are currently implemented in [ethers-provider-flashbots-bundle.js](/flashbots-auction/searchers/libraries/ethers-js-provider) and [web3-flashbots.py](/flashbots-auction/searchers/libraries/web3py-provider).
+These methods are currently implemented in [ethers-provider-flashbots-bundle.js](/flashbots-auction/searchers/libraries/ethers-js-provider), [web3-flashbots.py](/flashbots-auction/searchers/libraries/web3py-provider), and [Alchemy's ethers.js SDK](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/src/api/transact-namespace.ts). 
 
 <Tabs 
     defaultValue="ethers.js"


### PR DESCRIPTION
Added the Alchemy SDK as it also contains the ethers provider flashbots bundle and is an option for developers wanting to send private txns on a private API key.  