### PR TITLE
Update bundle-cancellation libraries

### DIFF
--- a/docs/flashbots-auction/searchers/advanced/bundle-cancellations.mdx
+++ b/docs/flashbots-auction/searchers/advanced/bundle-cancellations.mdx
@@ -35,7 +35,7 @@ To replace a bundle, send the new bundle via `eth_sendBundle` with the same `rep
 
 ### Canceling bundles
 
-Canceling a bundle will prevent Flashbots builders from including it on-chain. To cancel a bundle, call the [`eth_cancelBundle`](/flashbots-auction/searchers/advanced/rpc-endpoint#eth_cancelbundle) endpoint, or use the `cancelBundle` function in your preferred [Flashbots library](/flashbots-auction/searchers/libraries/ethers-js-provider).
+Canceling a bundle will prevent Flashbots builders from including it on-chain. To cancel a bundle, call the [`eth_cancelBundle`](/flashbots-auction/searchers/advanced/rpc-endpoint#eth_cancelbundle) endpoint, or use the `cancelBundle` function in your preferred Flashbots library -- either in [Flashbots's ethers.js provider library](https://docs.flashbots.net/flashbots-auction/searchers/libraries/ethers-js-provider) or in [Alchemy's ethers.js SDK's provider library](https://docs.flashbots.net/flashbots-auction/searchers/libraries/alchemyprovider).
 
 ```json
 {


### PR DESCRIPTION
Clarified which two libraries the eth_cancelBundle existed in to help developers directly understand which providers they could use. I work at Alchemy and we got dev feedback that this section was a bit unclear as they were building