### PR TITLE
update protect-button

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "docusaurus-plugin-sass": "0.2.1",
     "docusaurus2-dotenv": "^1.4.0",
     "dotenv": "^8.2.0",
-    "protect-button": "^0.3.0",
+    "protect-button": "^0.4.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "rehype-katex": "^4.0.0",

--- a/src/components/ProtectButtonSelector/index.tsx
+++ b/src/components/ProtectButtonSelector/index.tsx
@@ -59,7 +59,7 @@ const ProtectButtonSelector = () => {
         }}>
             <SimpleDropdown.Body>
                 <AlignItems horizontal='center'>
-                    <><FlashbotsProtectButton hints={advancedOptionsShown ? hints : undefined} targetBuilders={advancedOptionsShown ? selectedBuilders : undefined}>Connect Wallet to Protect</FlashbotsProtectButton></>
+                    <><FlashbotsProtectButton hints={advancedOptionsShown ? hints : undefined} builders={advancedOptionsShown ? selectedBuilders : undefined}>Connect Wallet to Protect</FlashbotsProtectButton></>
                 </AlignItems>
             </SimpleDropdown.Body>
             <SimpleDropdown.HiddenBody>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6076,10 +6076,10 @@ property-information@^5.0.0, property-information@^5.3.0:
   dependencies:
     xtend "^4.0.0"
 
-protect-button@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/protect-button/-/protect-button-0.3.0.tgz#b8473ad58c17ca0b08b61dddb972e7ba3d730ac6"
-  integrity sha512-P0KrxbcSEcHwNecjiHO++j37BmFerjhCVbmtwMrs/VSHaeVyKnxLnbG67aQQ54W3YWNMbQauh7l5hIrMRWjJJQ==
+protect-button@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/protect-button/-/protect-button-0.4.1.tgz#09bd224493f308af6c5f1ab58cee0766ed3a34ec"
+  integrity sha512-tzqwz1wC5KFHlIhPbwabwGYWiFtMpG+rGV06DX750OoKCYu1AMz6X9xXIEtJNsxrFR+TjsHQFHh4rzxC5cY9Dg==
 
 proxy-addr@~2.0.7:
   version "2.0.7"


### PR DESCRIPTION
- uses `builders` instead of `targetBuilders` and sets `?builder=XXX` in the Protect RPC URL