### PR TITLE
Update private transaction API docs

### DIFF
--- a/docs/flashbots-protect/rpc/status-api.md
+++ b/docs/flashbots-protect/rpc/status-api.md
@@ -12,13 +12,13 @@ In turn you will receive a JSON response that looks like the following:
     "hash": "YOUR_TX_HASH",
     "maxBlockNumber": 13543898,
     "transaction": {
-        "from": "0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8",
-        "to": "0xac03bb73b6a9e108530aff4df5077c2b3d481e5a",
-        "gasLimit": "21000",
-        "maxFeePerGas": "300",
-        "maxPriorityFeePerGas": "10",
-        "nonce": "41",
-        "value": "10000000000"
+        "from": "",
+        "to": "",
+        "gasLimit": "",
+        "maxFeePerGas": "",
+        "maxPriorityFeePerGas": "",
+        "nonce": "",
+        "value": ""
     },
   "fastMode": true, // for backwards compatibility; may be removed in a future version
   "seenInMempool": false,
@@ -36,4 +36,26 @@ In turn you will receive a JSON response that looks like the following:
 
 ## Privacy
 
-In order to receive a response from the status API you must know and provide a transaction hash to look up. As a result, you are only able to look up transactions which you know about.
+The `transaction` fields are only shared for INCLUDED transactions to respect pre- and failed- trade privacy. These fields will be empty for PENDING, FAILED, UNKNOWN, or CANCELLED transactions.
+
+For example, once the earlier transaction was included, you would receive a JSON response that contains data for all fields:
+
+```json
+{
+    "status": "INCLUDED",
+    "hash": "YOUR_TX_HASH",
+    "maxBlockNumber": 13543898,
+    "transaction": {
+        "from": "0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8",
+        "to": "0xac03bb73b6a9e108530aff4df5077c2b3d481e5a",
+        "gasLimit": "21000",
+        "maxFeePerGas": "300",
+        "maxPriorityFeePerGas": "10",
+        "nonce": "41",
+        "value": "10000000000"
+    },
+  "fastMode": true, // for backwards compatibility; may be removed in a future version
+  "seenInMempool": false,
+  "simError": "MaxFeePerGasTooLow"
+}
+```

--- a/docs/flashbots-protect/rpc/status-api.md
+++ b/docs/flashbots-protect/rpc/status-api.md
@@ -22,7 +22,6 @@ In turn you will receive a JSON response that looks like the following:
     },
   "fastMode": true, // for backwards compatibility; may be removed in a future version
   "seenInMempool": false,
-  "simError": "MaxFeePerGasTooLow"
 }
 ```
 
@@ -56,6 +55,5 @@ For example, once the earlier transaction was included, you would receive a JSON
     },
   "fastMode": true, // for backwards compatibility; may be removed in a future version
   "seenInMempool": false,
-  "simError": "MaxFeePerGasTooLow"
 }
 ```


### PR DESCRIPTION
The `transaction` field should not include data for transactions that have not been included on chain.