### PR TITLE
Update example RPC configs for MEV-Share

### DIFF
--- a/docs/flashbots-protect/rpc/mev-share.mdx
+++ b/docs/flashbots-protect/rpc/mev-share.mdx
@@ -61,5 +61,4 @@ This will completely hide all identifying transaction data sent to the Matchmake
 | MEV-Share Enabled (Stable) | `https://rpc.flashbots.net` |
 | Default privacy, only send to Flashbots | `https://rpc.flashbots.net?builder=flashbots` |
 | Max Privacy | `https://rpc.flashbots.net?hint=hash` |
-| Fast Execution | `https://rpc.flashbots.net?hint=logs&hint=function_selector&hint=contract_address&hint=hash` |
-| Max Speed & MEV Kickbacks (Low Privacy) | `https://rpc.flashbots.net?hint=calldata&hint=logs&hint=function_selector&hint=contract_address&hint=hash` |
+| Max Speed & MEV Kickbacks (Low Privacy) | `https://rpc.flashbots.net?hint=calldata&hint=logs&hint=hash` |


### PR DESCRIPTION
Contract address and function selector are automatically shared if calldata is shared.

Get rid of separate "fast execution" example, it's not particularly differentiated from "max speed & MEV kickbacks".