### PR TITLE
Describe a new header

### DIFF
--- a/docs/flashbots-auction/searchers/advanced/rpc-endpoint.mdx
+++ b/docs/flashbots-auction/searchers/advanced/rpc-endpoint.mdx
@@ -582,3 +582,15 @@ signature := crypto.PubkeyToAddress(privKey.PublicKey).Hex() + ":" + hexutil.Enc
 
 </TabItem>
 </Tabs>
+
+### Self-Reported Origin
+
+You have the option to add an X-Flashbots-Origin header to your request.
+This can help Flashbots understand the origin of your requests.
+
+In most cases, X-Flashbots-Signature would suffice.
+However, X-Flashbots-Origin is utilized when a request comes through an RPC endpoint where the requests are not signed.
+
+This can be any string that is less than 255 characters long.
+It's recommended to add secret randomness to the value to prevent others from impersonating you.
+For example, `X-Flashbots-Origin: my-readable-id:random`.


### PR DESCRIPTION
`X-Flashbots-Origin`  is kind of internal header relevant for rpc endpoint requests, but it can be used to help us recognize users in addition to signer.

We can omit this from docs because on the relay we have signer that is better way to identify users. We only need this header because rpc endpoint requests are not signed. 

@sketsdever take a look at the randomness description.