### PR TITLE
Rename matchmaker-ts to mev-share-client-ts and update examples

### DIFF
--- a/docs/flashbots-auction/searchers/libraries/mev-share-clients.md
+++ b/docs/flashbots-auction/searchers/libraries/mev-share-clients.md
@@ -4,6 +4,6 @@ title: MEV-Share Clients
 
 ### Typescript
 
-* [matchmaker-ts](https://github.com/flashbots/matchmaker-ts) - reference implementation
+* [mev-share-client-ts](https://github.com/flashbots/mev-share-client-ts) - reference implementation
 
 > :eyes: If you are writing (or want to write) a client library for MEV-Share, please [reach out](https://twitter.com/zeroXbrock). We love client diversity!

--- a/docs/flashbots-mev-share/overview.mdx
+++ b/docs/flashbots-mev-share/overview.mdx
@@ -10,7 +10,7 @@ Today, orderflow originators like wallets and dapps do not actively participate 
 [MEV-share](https://collective.flashbots.net/t/mev-share-programmably-private-orderflow-to-share-mev-with-users/1264) is a protocol that enables users, wallets, and dapps to **capture the MEV their transactions create.**
 
 ## Introduction
-> The MEV-Share Matchmaker was renamed to the MEV-Share Node to better reflect the role we envision this actor will play in SUAVE. This change will be reflected in our documentation after June 2023. Note that tutorials and client libraries like matchmaker-ts still use the term "Matchmaker", which is persisted here temporarily until those libraries are renamed.
+> The MEV-Share Matchmaker was renamed to the MEV-Share Node to better reflect the role we envision this actor will play in SUAVE. This change will be reflected in our documentation after June 2023. The client library previously named `matchmaker-ts` has also been renamed to `mev-share-client-ts`.
 
 ### What is MEV-share?
 

--- a/docs/flashbots-mev-share/searchers/event-stream.mdx
+++ b/docs/flashbots-mev-share/searchers/event-stream.mdx
@@ -10,25 +10,23 @@ Events on MEV-Share are distributed via an SSE endpoint. Searchers listen to thi
 
 ## Quickstart
 
-Subscribe to the stream by making an HTTP GET request on the stream endpoint. The [matchmaker-ts](https://npmjs.com/@flashbots/matchmaker-ts) library implements this as an asynchronous event handler.
-
-> Note: The MEV-Share Matchmaker was renamed to the MEV-Share Node to better reflect the role we envision this actor will play in SUAVE. The following tutorial will update once this change is reflected in the matchmaker-ts client library.
+Subscribe to the stream by making an HTTP GET request on the stream endpoint. The [mev-share-client-ts](https://npmjs.com/@flashbots/mev-share-client) library implements this as an asynchronous event handler.
 
 <Tabs>
-<TabItem value="ts" label="matchmaker-ts">
+<TabItem value="ts" label="mev-share-client-ts">
 
 ```typescript
-import Matchmaker, { IPendingTransaction, IPendingBundle, StreamEvent } from '@flashbots/matchmaker-ts'
+import MevShareClient, { IPendingTransaction, IPendingBundle, StreamEvent } from '@flashbots/mev-share-client'
 
-const matchmaker = Matchmaker.useEthereumMainnet(authSigner)
+const mevShareClient = MevShareClient.useEthereumMainnet(authSigner)
 
-const txHandler = matchmaker.on(StreamEvent.Transaction, (tx: IPendingTransaction) => {
+const txHandler = mevShareClient.on(StreamEvent.Transaction, (tx: IPendingTransaction) => {
     /*
     Do something with the pending tx here.
     */
 })
 
-const bundleHandler = matchmaker.on(StreamEvent.Bundle, (tx: IPendingBundle) => {
+const bundleHandler = mevShareClient.on(StreamEvent.Bundle, (tx: IPendingBundle) => {
     /*
     Do something with the pending bundle here.
     */

--- a/docs/flashbots-mev-share/searchers/getting-started.mdx
+++ b/docs/flashbots-mev-share/searchers/getting-started.mdx
@@ -11,45 +11,43 @@ To start searching on MEV-Share, you will first need to connect to a MEV-Share N
 
 Flashbots runs a MEV-Share Node on Ethereum mainnet. The MEV-Share Node has endpoints to receive transactions and bundles, as well as an SSE event stream endpoint which dispatches pending events/transactions to searchers.
 
-The simplest way to connect to the Flashbots MEV-Share Node is to use a [client library](/flashbots-auction/searchers/libraries/mev-share-clients). For this guide, we'll refer to [matchmaker-ts](https://github.com/flashbots/matchmaker-ts).
-
-> Note: The MEV-Share Matchmaker was renamed to the MEV-Share Node to better reflect the role we envision this actor will play in SUAVE. The following tutorial will update once this change is reflected in the matchmaker-ts client library.
+The simplest way to connect to the Flashbots MEV-Share Node is to use a [client library](/flashbots-auction/searchers/libraries/mev-share-clients). For this guide, we'll refer to [mev-share-client-ts](https://github.com/flashbots/mev-share-client-ts).
 
 <Tabs>
-<TabItem value="ts" label="matchmaker-ts">
+<TabItem value="ts" label="mev-share-client-ts">
 
 _Add library to your project:_
 
 ```sh
-yarn add @flashbots/matchmaker-ts
+yarn add @flashbots/mev-share-client
 ```
 
 _Import library code (note `ALL_CAPS` variables are placeholders; replace with your own data):_
 
 ```typescript
 import { Wallet, JsonRpcProvider } from "ethers"
-import Matchmaker, {
+import MevShareClient, {
     ShareBundleParams,
     PendingShareTransaction,
     ShareTransactionOptions
-} from "@flashbots/matchmaker-ts"
+} from "@flashbots/mev-share-client"
 
 const provider = new JsonRpcProvider(RPC_URL)
 const authSigner = new Wallet(FB_REPUTATION_PRIVATE_KEY, provider)
-const matchmaker = Matchmaker.useEthereumMainnet(authSigner)
+const mevShareClient = MevShareClient.useEthereumMainnet(authSigner)
 ```
 
 _Connecting to Goerli:_
 
 ```typescript
-const matchmaker = Matchmaker.useEthereumGoerli(authSigner)
+const mevShareClient = MevShareClient.useEthereumGoerli(authSigner)
 ```
 
 _Custom params (for developers):_
 
 ```typescript
-// connect to matchmaker on mainnet
-const matchmaker = new Matchmaker(authSigner, {
+// connect to MEV-Share on mainnet
+const mevShareClient = new MevShareClient(authSigner, {
     name: "mainnet",
     chainId: 1,
     streamUrl: "https://mev-share.flashbots.net",
@@ -57,7 +55,7 @@ const matchmaker = new Matchmaker(authSigner, {
 })
 ```
 
-See the documentation in the [matchmaker-ts](https://github.com/flashbots/matchmaker-ts) repo to learn more.
+See the documentation in the [mev-share-client-ts](https://github.com/flashbots/mev-share-client-ts) repo to learn more.
 
 ### note A note on other languages
 

--- a/docs/flashbots-mev-share/searchers/sending-bundles.mdx
+++ b/docs/flashbots-mev-share/searchers/sending-bundles.mdx
@@ -17,15 +17,13 @@ Variables in `ALL_CAPS` are placeholders. To use this code, replace them with yo
 
 :::
 
-> Note: The MEV-Share Matchmaker was renamed to the MEV-Share Node to better reflect the role we envision this actor will play in SUAVE. The following tutorial will update once this change is reflected in the matchmaker-ts client library.
-
 <Tabs>
-<TabItem value="ts" label="matchmaker-ts">
+<TabItem value="ts" label="mev-share-client-ts">
 
 ```typescript
-import MEV-Share Node, { BundleParams } from '@flashbots/matchmaker-ts'
+import MevShareClient, { BundleParams } from '@flashbots/mev-share-client'
 
-const matchmaker = MEV-Share Node.useEthereumMainnet(authSigner)
+const mevShareClient = MevShareClient.useEthereumMainnet(authSigner)
 
 // ...
 
@@ -43,7 +41,7 @@ const params: BundleParams = {
     body: bundle,
 }
 
-const bundleResult = await matchmaker.sendBundle(params)
+const bundleResult = await mevShareClient.sendBundle(params)
 ```
 
 The first transaction in the bundle contains the hash of a pending transaction, which we presumably got from listening to the [event stream](/flashbots-mev-share/searchers/event-stream). The second transaction is one we sign ourself, which backruns the first transaction, presumably for a profit.
@@ -54,7 +52,7 @@ MEV-Share bundles are sent to the same RPC endpoint as MEV-Boost bundles: `https
 
 :::
 
-See [matchmaker-ts](https://github.com/flashbots/matchmaker-ts/blob/main/src/examples/sendBackrunBundle.ts) for a full working example.
+See [mev-share-client-ts](https://github.com/flashbots/mev-share-client-ts/blob/main/src/examples/sendBackrunBundle.ts) for a full working example.
 
 </TabItem>
 </Tabs>
@@ -74,7 +72,7 @@ Note that bundles with transactions including the `hash` parameter are considere
 :::
 
 <Tabs>
-<TabItem value="ts" label="matchmaker-ts">
+<TabItem value="ts" label="mev-share-client-ts">
 
 ```typescript
 const params: BundleParams = {
@@ -126,7 +124,7 @@ This strategy is particularly relevant to searchers who operate on public mempoo
 MEV-Share Nodes nest bundles to build composite bundles that are more profitable.
 
 <Tabs>
-<TabItem value="ts" label="matchmaker-ts">
+<TabItem value="ts" label="mev-share-client-ts">
 
 ```typescript
 const params: BundleParams = {
@@ -163,7 +161,7 @@ Bundle simulations can only be executed on matched bundles, which contain only s
 :::
 
 <Tabs>
-<TabItem value="ts" label="matchmaker-ts">
+<TabItem value="ts" label="mev-share-client-ts">
 
 ```typescript
 const params: BundleParams = {
@@ -192,7 +190,7 @@ const params: BundleParams = {
     }
 }
 
-const simResult = await matchmaker.simulateBundle(params)
+const simResult = await mevShareClient.simulateBundle(params)
 ```
 
 </TabItem>

--- a/docs/flashbots-mev-share/searchers/understanding-bundles.mdx
+++ b/docs/flashbots-mev-share/searchers/understanding-bundles.mdx
@@ -35,10 +35,8 @@ One example that works well with bundle composition is a liquidation bot. Liquid
 
 An example would look something like this:
 
-> Note: The MEV-Share Matchmaker was renamed to the MEV-Share Node to better reflect the role we envision this actor will play in SUAVE. The following tutorial will update once this change is reflected in the matchmaker-ts client library.
-
 <Tabs>
-<TabItem value="ts" label="matchmaker-ts">
+<TabItem value="ts" label="mev-share-client-ts">
 
 ```typescript
 const params: BundleParams = {


### PR DESCRIPTION
We've renamed `matchmaker-ts` to `mev-share-client-ts`. This PR updates
* References thee the old name/repo -- rename
* Example code snippets -- import new package, use "MevShareClient" instead of "Matchmaker" export

A few outstanding notes and questions
* The NPM package is called "mev-share-client" but the repo is "mev-share-client-**ts**". This small difference seems like it might trip people up? Previously we had applied the "-ts" postfix to both, I think it could be good to be consistent (esp as we will have other client libs in other languages)
* I'm not sure it's necessary to add the word "client". It makes the name more verbose and IMO isn't that much clearer. Curious what others think.
* Whatever we choose, we should be consistent across languages/clients. Specifically, can we add instructions to our client guidelines for other languages that establish consistent naming pattern for both the repo/package and the name of the default export (or equivalent for those languages)?