### PR TITLE
shows advanced options for Flashbots Protect by default

### DIFF
--- a/src/components/ProtectButtonSelector/index.tsx
+++ b/src/components/ProtectButtonSelector/index.tsx
@@ -16,7 +16,7 @@ const ProtectButtonSelector = () => {
     const [noHints, setNoHints] = useState(false)
     const [curatedBuilders, setCuratedBuilders] = useState<Builder[]>()
     const [allBuilders, setAllBuilders] = useState(false)
-    const [advancedOptionsShown, setAdvancedOptionsShown] = useState(false)
+    const [advancedOptionsShown, setAdvancedOptionsShown] = useState(true)
 
     const hints = advancedOptionsShown ? {
         calldata,
@@ -96,7 +96,7 @@ const ProtectButtonSelector = () => {
     return (<GridBlock>
         <SimpleDropdown header={"Advanced options"} onClickHeader={() => {
             setAdvancedOptionsShown(!advancedOptionsShown)
-        }}>
+        }} isOpen={advancedOptionsShown}>
             <SimpleDropdown.Body>
                 <AlignItems horizontal='center'>
                     <><FlashbotsProtectButton hints={advancedOptionsShown ? hints : undefined} builders={advancedOptionsShown ? selectedBuilders : undefined}>Connect Wallet to Protect</FlashbotsProtectButton></>

--- a/src/components/SimpleDropdown/index.tsx
+++ b/src/components/SimpleDropdown/index.tsx
@@ -5,9 +5,10 @@ type SimpleDropdownParams = {
     header: string,
     italicHeader?: boolean,
     onClickHeader?: (e: any) => void,
+    isOpen: boolean,
 }
 
-const SimpleDropdown = ({ children, header, italicHeader, onClickHeader }: PropsWithChildren<SimpleDropdownParams>) => {
+const SimpleDropdown = ({ children, header, italicHeader, onClickHeader, isOpen }: PropsWithChildren<SimpleDropdownParams>) => {
     const useItalic = italicHeader !== false // default to true
     const subComponentList = Object.keys(SimpleDropdown)
 
@@ -20,8 +21,8 @@ const SimpleDropdown = ({ children, header, italicHeader, onClickHeader }: Props
     return (
         <div className='dropdown-container'>
             {subComponents[0]}
-            <details>
-                <summary className={styles.dropdownHeader} onClick={onClickHeader}>
+            <details open={isOpen} onClick={onClickHeader}>
+                <summary className={styles.dropdownHeader}>
                     {useItalic ? <em>{header}</em> : header}
                 </summary>
                 {subComponents[1]}


### PR DESCRIPTION
### Problem:

We want to set the advanced options for Flashbots Protect in pages like [this](https://docs.flashbots.net/flashbots-protect/overview) to be by default true.

In the current implementation, even when the `advancedOptionsShown` state was set to `true` in `src/components/ProtectButtonSelector/index.tsx`, it did not affect the visibility of the dropdown component in `src/components/SimpleDropdown/index.tsx`. The `SimpleDropdown` component was not aware of the `advancedOptionsShown` state and had no control to set the dropdown to be open or closed based on this state.

### Solution:
To fix this issue, the following changes were made:

1. **Added a new prop `isOpen` to `SimpleDropdown`:** This prop is used to control the visibility of the dropdown. When `isOpen` is `true`, the dropdown will be shown by default.

2. **Passed `advancedOptionsShown` as `isOpen` to `SimpleDropdown`:** In `src/components/ProtectButtonSelector/index.tsx`, the `advancedOptionsShown` state is now passed to `SimpleDropdown` as the `isOpen` prop. This links the visibility state directly to the dropdown, ensuring it opens or closes based on this value.

3. **Used the `open` attribute in the `details` tag:** Within `SimpleDropdown`, the `open` attribute is used to control the visibility of the dropdown, based on the value of the `isOpen` prop.

### Files Changed:
- `src/components/SimpleDropdown/index.tsx`
- `src/components/ProtectButtonSelector/index.tsx`

### Testing:
Please verify the changes by navigating to the Protect Button Selector component and ensuring that the dropdown is shown by default and behaves correctly when toggling the "Advanced options."
