### PR TITLE
Add ETHGlobal Hackathon banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,6 +57,12 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
             position: 'right',
           },
         ],
+      },
+      announcementBar: {
+        id: "ETHGlobal",
+        content:
+          '<span>🍎</span><a href="https://collective.flashbots.net/t/ethglobal-ny-hackathon-sept-22-24/2413" target="_blank" rel="noreferrer">Participate in the Flashbots hackathon track at ETHGlobal NY, Sept 22 - 24</a><span>🍎</span>',
+        isCloseable: false,
       }
       
     }),

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -115,3 +115,44 @@ h2 {
     background-image: linear-gradient(transparent, rgba(0, 0, 0, .05) 40%, rgba(0, 0, 0, .1));
   }
 }
+
+/* Top banner */
+div[role=banner] { 
+  min-height: 32px;
+
+  > div {
+    min-height: 32px;
+    padding: 0px;
+    border: 0px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    column-gap: 10px;
+    background-color: #f1be47;
+    color: #000000;
+    text-align: center;
+    font-size: 100%;
+
+    a {
+      font-family: "CMU-Serif";
+      font-size: 16px;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
+@media (min-width: 341px) and (max-width: 640px) {
+  div[role=banner] > div a {
+    flex-basis: 280px;
+  }
+}
+
+@media (max-width: 340px) {
+  div[role=banner] > div a {
+    flex-basis: 150px;
+  }
+}


### PR DESCRIPTION
# What
This PR adds a banner to the top of the Documentation page to promote the ETHGlobal Hackathon in NYC, coming up this weekend. 

The banner should be identical to the ones going live on the Flashbots [Homepage](https://github.com/flashbots/flashbots-website/pull/56) and [Writings](https://github.com/flashbots/flashbots-writings-website/pull/121).

<p align="center">
  <img src="https://github.com/flashbots/flashbots-docs/assets/68292774/78ec8d1d-e1c8-4b84-8ea5-ff280ad197ee" alt="Screenshot of the new webpage with a banner"/>
</p>