### PR TITLE
Set up .env.template instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ yarn install
 
 ## Local Development
 
+```sh
+cp .env.template .env
+```
+
+First create a local `.env` file to fill in env variable placeholders necessary for setting up the development. Note that these are merely placeholders.
+
 ```console
 yarn start
 ```

--- a/README.md
+++ b/README.md
@@ -22,19 +22,18 @@ yarn install
 
 ## Local Development
 
+First create a local `.env` file to fill in env variable placeholders necessary for setting up the development. Note that these are merely placeholders.
+
 ```sh
 cp .env.template .env
 ```
-
-First create a local `.env` file to fill in env variable placeholders necessary for setting up the development. Note that these are merely placeholders.
+Then run the below command to start a local development server (and may open up a browser window). Some changes are reflected live without having to restart the server.
 
 ```console
 yarn start
 ```
 
-This command starts a local development server (and may open up a browser window). Some changes are reflected live without having to restart the server.
-
-You can open the local docs at [http://localhost:3000/docs](http://localhost:3000/docs)
+You can open the local docs at [http://localhost:3000/](http://localhost:3000/)
 
 ## Build
 


### PR DESCRIPTION
Add instruction for users to set up `.env` using `.env.template` for local development