### PR TITLE
Remove mentions of Sepolia relay

### DIFF
--- a/docs/flashbots-auction/advanced/testnets.mdx
+++ b/docs/flashbots-auction/advanced/testnets.mdx
@@ -2,7 +2,7 @@
 title: Testnets
 ---
 
-Flashbots operates on Goerli and Sepolia, so that searchers can test Flashbots without risking real funds. 
+Flashbots operates on Goerli so that searchers can test Flashbots without risking real funds. 
 
 ## Bundle Relay URLS
 
@@ -10,16 +10,13 @@ Flashbots operates on Goerli and Sepolia, so that searchers can test Flashbots w
 | --- | --- |
 | Mainnet | `https://relay.flashbots.net` |
 | Goerli | `https://relay-goerli.flashbots.net` |
-| Sepolia | `https://relay-sepolia.flashbots.net` |
 
 ## Examples
 
-Here's how to setup the Flashbots Bundle Provider in Ethers to use Goerli or Sepolia:
+Here's how to setup the Flashbots Bundle Provider in Ethers to use Goerli:
 
 ```js
 const provider = new ethers.getDefaultProvider("goerli");
-// uncomment the line below to use Sepolia
-// const provider = new ethers.getDefaultProvider("sepolia");
 
 const authSigner = new ethers.Wallet(
   '0x2000000000000000000000000000000000000000000000000000000000000000',
@@ -29,7 +26,6 @@ const authSigner = new ethers.Wallet(
 const flashbotsProvider = await flashbots.FlashbotsBundleProvider.create(
   provider,
   authSigner,
-  // use "https://relay-sepolia.flashbots.net" for Sepolia
   "https://relay-goerli.flashbots.net",
   "goerli"
 );

--- a/docs/flashbots-auction/quick-start.mdx
+++ b/docs/flashbots-auction/quick-start.mdx
@@ -15,7 +15,6 @@ See you on-chain! ⚡🤖
 | ------- | ------------------------------------- |
 | Mainnet | `https://relay.flashbots.net`         |
 | Goerli  | `https://relay-goerli.flashbots.net`  |
-| Sepolia | `https://relay-sepolia.flashbots.net` |
 
 ### Who should use Flashbots Auction?
 


### PR DESCRIPTION
[According to brock](https://discord.com/channels/755466764501909692/1061340123683377274/1189291168719192135) and [this commit](https://github.com/flashbots/flashbots-docs/commit/a935dac51928cf5142e4c707b03a40fa43fe4d56), the Sepolia relay is not active, yet it is still listed in the docs.