### PR TITLE
Add 'co-locate' to advanced section in flashbots-auction

### DIFF
--- a/docs/flashbots-auction/advanced/co-locate.mdx
+++ b/docs/flashbots-auction/advanced/co-locate.mdx
@@ -1,0 +1,7 @@
+---
+title: Co-locate with Flashbots Builder
+---
+
+For searchers who want to optimize the latency of their bundle submission, they can choose to co-locate with Flashbots Builders.
+
+The Flashbots Builder is located in Ohio, USA. Specifically, it is located in the AWS `us-east-2` region.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -40,6 +40,7 @@ module.exports = {
             'flashbots-auction/advanced/eip1559',
             'flashbots-auction/advanced/troubleshooting',
             'flashbots-auction/advanced/bundle-cancellations',
+            'flashbots-auction/advanced/co-locate',
           ],
         },
         'flashbots-auction/faq',


### PR DESCRIPTION
In this pull request, we are adding a new section called 'co-locate' to the advanced section in the flashbots-auction repository. This section provides information for searchers who want to optimize the latency of their bundle submission by co-locating with Flashbots Builders. The Flashbots Builder is located in Ohio, USA, specifically in the AWS `us-east-2` region. This addition will enhance the documentation and help users make informed decisions.