### PR TITLE
Add API shortcut to navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -51,12 +51,22 @@ module.exports = async function createConfigAsync() {
           }
         },
         navbar: {
-          title: 'Flashbots Docs',
+          title: 'Flashbots',
           logo: {
             alt: 'Flashbots Logo',
             src: 'img/logo.png',
           },
           items: [
+            {
+              to: '/',
+              label: 'Docs',
+              position: 'left',
+            },
+            {
+              to: '/flashbots-auction/advanced/rpc-endpoint',
+              label: 'API',
+              position: 'left',
+            },
             {
               href: 'https://github.com/flashbots/docs',
               label: 'GitHub',


### PR DESCRIPTION
This pull request adds a shortcut to the API section in the navbar. Users can now easily navigate to the API documentation from any page on the website.