### PR TITLE
Add activeBasePath to navigation links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,11 +61,13 @@ module.exports = async function createConfigAsync() {
               to: '/',
               label: 'Docs',
               position: 'left',
+              activeBasePath: 'docs',
             },
             {
               to: '/flashbots-auction/advanced/rpc-endpoint',
               label: 'API',
               position: 'left',
+              activeBasePath: 'flashbots-auction',
             },
             {
               href: 'https://github.com/flashbots/docs',


### PR DESCRIPTION
This pull request adds the `activeBasePath` property to the navigation links in the documentation and API sections. This property allows for better navigation and highlighting of the current active page.