### PR TITLE
Create standalone sidebar for API

### DIFF
--- a/docs/flashbots-auction/advanced/rpc-endpoint.mdx
+++ b/docs/flashbots-auction/advanced/rpc-endpoint.mdx
@@ -1,5 +1,5 @@
 ---
-title: RPC Endpoint
+title: JSON-RPC Endpoints
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -34,7 +34,6 @@ module.exports = {
             'flashbots-auction/advanced/understanding-bundles',
             'flashbots-auction/advanced/coinbase-payment',
             'flashbots-auction/advanced/bundle-pricing',
-            'flashbots-auction/advanced/rpc-endpoint',
             'flashbots-auction/advanced/reputation',
             'flashbots-auction/advanced/testnets',
             'flashbots-auction/advanced/eip1559',
@@ -58,9 +57,7 @@ module.exports = {
         {
           'Additional Documentation': [
             'flashbots-protect/additional-documentation/eth-sendPrivateTransaction',
-            'flashbots-protect/additional-documentation/status-api',
             'flashbots-protect/additional-documentation/ratelimiting',
-            'flashbots-protect/additional-documentation/bundle-cache',
           ],
         }
       ],
@@ -192,4 +189,9 @@ module.exports = {
     },
         'policies/privacy','policies/terms-of-service', 'policies/prohibited-use-policy', 'brand-assets',
   ],
+  api: [
+    "flashbots-auction/advanced/rpc-endpoint",
+    "flashbots-protect/additional-documentation/status-api",
+    "flashbots-protect/additional-documentation/bundle-cache",
+  ]
 };

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -58,13 +58,15 @@ module.exports = async function createConfigAsync() {
           },
           items: [
             {
-              to: '/',
+              type: 'docSidebar',
               label: 'Docs',
+              sidebarId: 'docs',
               position: 'left',
             },
             {
-              to: '/flashbots-auction/advanced/rpc-endpoint',
+              type: 'docSidebar',
               label: 'API',
+              sidebarId: 'api',
               position: 'left',
             },
             {


### PR DESCRIPTION
This pull request adds a standalone sidebar for the API section in the documentation. It includes changes to the configuration file and the sidebar component. The sidebar now has a separate section for API documentation, making it easier for users to navigate and find relevant information. This improves the overall user experience and organization of the documentation.

This PR also starts the migration of relevant API documents to the API sidebar from the docs sidebar.