### PR TITLE
Update builder list

### DIFF
--- a/docs/flashbots-mev-boost/block-builders.md
+++ b/docs/flashbots-mev-boost/block-builders.md
@@ -61,11 +61,11 @@ The various `builder_pubkeys` used to identify Flashbots builders to relays are
 | -------------------------------------------------------------------------------------------------- |
 | 0x81babeec8c9f2bb9c329fd8a3b176032fe0ab5f3b92a3f44d4575a231c7bd9c31d10b6328ef68ed1e8c02a3dbc8e80f9 |
 | 0x81beef03aafd3dd33ffd7deb337407142c80fea2690e5b3190cfc01bde5753f28982a7857c96172a75a234cb7bcb994f |
-| 0xa1dead01e65f0a0eee7b5170223f20c8f0cbf122eac3324d61afbdb33a8885ff8cab2ef514ac2c7698ae0d6289ef27fc  |
+| 0xa1dead01e65f0a0eee7b5170223f20c8f0cbf122eac3324d61afbdb33a8885ff8cab2ef514ac2c7698ae0d6289ef27fc |
 | 0xa1defa73d675983a6972e8686360022c1ebc73395067dd1908f7ac76a526a19ac75e4f03ccab6788c54fdb81ff84fc1b |
 | 0x81babad2d5fd9413c942f49bfd86bc1dca5b02ff4cd065a10c7ab05713e63883056e6a87777e236424574aa25bbe3e99 |
-| 0xa35e2b13ef528efbed8d2f709c0eb9eceb1225ed0605a653ba923588b0150c94772a9ba1c809d048e321f6b73d905c60 |
 | 0xb89b9308fbc6c2998c7e60e39424b858c74b02c234b3e0fa5ecf7c3971208dfa5f92e0bdbe16fc24abfd71c248acf0f9 |
+| 0xa1f1a5a4970903afd6f0f16049c3e9997d348a3254e99b08e89ffb553d0b1575595776b1d849ca2e8d64106443a47e76 |
 
 ## Additional Links & References
 


### PR DESCRIPTION
This pull request updates the builder list by adding a new builder pubkey (rbuilder) and removing an existing one (one SGX builder no longer producing blocks).