### PR TITLE
Add multiplexing to advanced concepts

### DIFF
--- a/docs/flashbots-auction/advanced/multiplexing.mdx
+++ b/docs/flashbots-auction/advanced/multiplexing.mdx
@@ -1,0 +1,13 @@
+---
+title: Send transaction/bundle to multiple builders
+---
+
+import Builders from '../../specs/mev-share/_builders.mdx';
+
+Some users might want to send their transactions or bundles to multiple builders for various reasons. The ability to multiplex is supported by our APIs.
+
+When you are using [`mev_sendBundle`](https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint#mev_sendbundle) to send bundle, or [`eth_sendPrivateTransaction`](https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint#eth_sendprivatetransaction) to send transaction, simply specify the builders you want to multiplex to in the `privacy.builders` parameter.
+
+Below is the list of builders that you can multiplex to:
+
+<Builders />

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -32,6 +32,7 @@ module.exports = {
           ],
           "Advanced Concepts": [
             'flashbots-auction/advanced/understanding-bundles',
+            'flashbots-auction/advanced/multiplexing',
             'flashbots-auction/advanced/coinbase-payment',
             'flashbots-auction/advanced/bundle-pricing',
             'flashbots-auction/advanced/reputation',

--- a/docs/welcome.mdx
+++ b/docs/welcome.mdx
@@ -23,6 +23,7 @@ Flashbots is a research and development organization formed to mitigate the nega
 Discover how to capture MEV opportunities on Ethereum responsibly with Flashbots.
 
 - [Understanding Bundles](/flashbots-auction/advanced/understanding-bundles)<br/>
+- [Multiplexing](/flashbots-auction/advanced/multiplexing)<br/>
 - [RPC Docs](/flashbots-auction/advanced/rpc-endpoint)<br/>
 - [Client Libs](/flashbots-auction/libraries/ethers-js-provider)<br/>
 - [Help & FAQs](https://collective.flashbots.net/tags/c/searchers/12/question)


### PR DESCRIPTION
This pull request adds the concept of multiplexing to the advanced concepts section. It shows users that they already can send their transactions or bundles to multiple builders by specifying the builders in the `privacy.builders` parameter. The pull request also includes the necessary file changes to support this feature.