### PR TITLE
Remove unnecessary repetition welcome.mdx

### DIFF
--- a/docs/welcome.mdx
+++ b/docs/welcome.mdx
@@ -40,7 +40,7 @@ Link your wallet to Flashbots Protect to safeguard against frontrunning, benefit
 </GridBlock>
 <GridBlock symbol="III." title="Validators, Builders & Relayers">
 
-Validators and builders, leverage MEV-Boost to access a competitive block-building market, fostering greater competition, decentralization, and censorship-resistance for Ethereum.
+Leverage MEV-Boost to access a competitive block-building market, fostering greater competition, decentralization, and censorship-resistance for Ethereum.
 
 - [Mev-Boost Docs](/flashbots-mev-boost/introduction)<br/>
 


### PR DESCRIPTION
I removed unnecessary text. Specifically the terms "Validators, Builders" are already mentioned in the block heading. If you look at the other blocks "Searchers" and "Eth Users" you can see the block title is not repeated in the text. 