### PR TITLE
SEO: Fix broken links

### DIFF
--- a/docs/flashbots-auction/libraries/alchemyprovider.md
+++ b/docs/flashbots-auction/libraries/alchemyprovider.md
@@ -15,6 +15,6 @@ To get started:
 
 * [https://www.alchemy.com/sdk](https://www.alchemy.com/sdk)
 
-* [https://docs.alchemy.com/reference/eth-sendprivatetransaction-sdk-v3](https://docs.alchemy.com/reference/sendprivatetransaction-sdk-v3)
+* [https://docs.alchemy.com/reference/sendprivatetransaction-sdk-v3](https://docs.alchemy.com/reference/sendprivatetransaction-sdk-v3)
 
 * [https://github.com/alchemyplatform/alchemy-sdk-js](https://github.com/alchemyplatform/alchemy-sdk-js)

--- a/docs/flashbots-mev-boost/architecture-overview/specifications.md
+++ b/docs/flashbots-mev-boost/architecture-overview/specifications.md
@@ -25,4 +25,3 @@ title: MEV-Boost Specifications
 - [MEV-Boost Relay](https://github.com/flashbots/mev-boost-relay)
 - [Go Boost Utils](https://github.com/flashbots/go-boost-utils)
 - [MEV-Boost Builder](https://github.com/flashbots/boost-geth-builder)
-- [Relay Status Page ](https://0xpanoramix.github.io/flashbots-boost-status/)

--- a/docs/flashbots-mev-boost/community-tools.md
+++ b/docs/flashbots-mev-boost/community-tools.md
@@ -1,9 +1,0 @@
----
-title: Community Tools
----
-
-## Flashbots Relayer Status
-
-[Monitor Flashbots Relays](https://0xpanoramix.github.io/flashbots-boost-status/) status on various timescales, by 0xpanoramix.
-
-![Untitled](https://www.notion.so/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F4c213924-8672-4c83-9e9f-605c5399503d%2FUntitled.png?table=block&id=5fce516f-d542-4ff1-8f46-a2f127897e49&spaceId=075d04b3-e5c0-4a97-8020-80f2e2b2206e&width=2000&userId=5d4ec963-edaf-46de-9bbd-bec711cebde4&cache=v2)

--- a/docs/joining-flashbots.mdx
+++ b/docs/joining-flashbots.mdx
@@ -5,7 +5,7 @@ title: Join Flashbots
 ### Interested in joining Flashbots?
 If you are a self-directed individual who puts collective success above your own and are motivated by solving hard problems with asymmetric impact, you will fit right in.
 
-* [Open job positions](https://boards.greenhouse.io/flashbots) - full-time roles we're actively recruiting for.
+* [Open job positions](https://www.flashbots.net/jobs) - full-time roles we're actively recruiting for.
 * [Flashbots research fellowship](https://github.com/flashbots/mev-research/blob/main/grants.md) - we issue research grants to flashbots research proposals submitters. Find out more in our research repo.
 * Flashbots part-time contractor - become a part-time contractor in Flashbots and join one of our ongoing projects. Reach out to the team to learn more!
 * Nothing fits in the above? reach out at jobs@flashbots.net

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -113,7 +113,6 @@ module.exports = {
           'flashbots-mev-boost/FAQ',
           'flashbots-mev-boost/glossary',
           'flashbots-mev-boost/resources',
-          'flashbots-mev-boost/community-tools',
       ],
     },
     {


### PR DESCRIPTION
Fixing rotten links in the docs, following the SEO report.

Of note just the fact the Flashbots Boost Status project seems to be dead, so I removed all references to it, which then led to the deletion of the `flashbots-mev-boost/community-tools` page, as that project was the only item there.

---
Task: [Link Errors](https://docs.google.com/presentation/d/1zRznWdOHz9ijfv-TOfkGSjqHv5gAFSETFtJ-e1d6wvI/edit#slide=id.g23787afad68_1_60)

Following the SEO guide here: https://docs.google.com/spreadsheets/d/13Xa_TKfuKrWzrK0zCgJNnQPXFK95hiBxqnLWE7cvHN8/edit#gid=1433029980