### PR TITLE
SEO: Fix broken backlinks

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -18,6 +18,31 @@
       "permanent": true
     },
     {
+      "source": "/flashbots-protect/rpc/fast-mode",
+      "destination": "/flashbots-protect/quick-start#faster-transactions",
+      "permanent": true
+    },
+    {
+      "source": "/flashbots-protect/api/json-rpc",
+      "destination": "/flashbots-auction/advanced/rpc-endpoint",
+      "permanent": true
+    },
+    {
+      "source": "/flashbots-mev-share/overview",
+      "destination": "/flashbots-mev-share/introduction",
+      "permanent": true
+    },
+    {
+      "source": "/flashbots-mev-boost/relays",
+      "destination": "/flashbots-mev-boost/relay",
+      "permanent": true
+    },
+    {
+      "source": "/flashbots-mev-boost/architecture-overview/MEV-boost-block-proposal",
+      "destination": "/flashbots-mev-boost/architecture-overview/block-proposal",
+      "permanent": true
+    },
+    {
       "source": "/flashbots-auction/searchers/:path*",
       "destination": "/flashbots-auction/:path",
       "permanent": true


### PR DESCRIPTION
Some pages across the web were linking to the Docs in ways that would return 404. This PR adds new rules to the `vercel.json` file to cover a handful of these cases.

Not all of the cases listed in the spreadsheet are covered, because I couldn't find an equivalent existing page to redirect to, as some of the pages have been entirely removed from the docs, or the projects no longer exist, or there's just a typo in the original URL.

But if there's anything I missed, just let me know.

---
Task: [Broken Backlinks](https://docs.google.com/presentation/d/1zRznWdOHz9ijfv-TOfkGSjqHv5gAFSETFtJ-e1d6wvI/edit#slide=id.g2644e6def94_0_72)

Following the SEO guide here: https://docs.google.com/spreadsheets/d/13Xa_TKfuKrWzrK0zCgJNnQPXFK95hiBxqnLWE7cvHN8/edit#gid=1086684444