### PR TITLE
add sepolia and holesky as mev-share endpoints

### DIFF
--- a/docs/flashbots-mev-share/searchers/event-stream.mdx
+++ b/docs/flashbots-mev-share/searchers/event-stream.mdx
@@ -74,6 +74,8 @@ Events currently represent pending transactions, but eventually may be expanded 
 |-|-|
 | Mainnet | https://mev-share.flashbots.net |
 | Goerli | https://mev-share-goerli.flashbots.net |
+| Holesky | https://mev-share-holesky.flashbots.net |
+| Sepolia | https://mev-share-sepolia.flashbots.net |
 
 The endpoint sends an event with the message `:ping` every 15 seconds if no other messages were sent in the last 15 seconds.
 


### PR DESCRIPTION
[link to change in preview](https://flashbots-docs-git-share-testnets-flashbots.vercel.app/flashbots-mev-share/searchers/event-stream#event-stream-endpoints)