### PR TITLE
Corrected Error in overview.mdx

### DIFF
--- a/docs/flashbots-auction/overview.mdx
+++ b/docs/flashbots-auction/overview.mdx
@@ -22,7 +22,7 @@ We've noted with deep concern about the rise of exclusive transaction routing in
 - November 2020: Formation of Flashbots Research Organization and proposal of [Flashbots Auction architecture](https://ethresear.ch/t/flashbots-frontrunning-the-mev-crisis/8251).
 - January 2021: Flashbots Auction Alpha (v0.1) made available for miners and searchers to adopt.
 - May 2021: Flashbots Auction Alpha (v0.2) made available for miners and searchers to adopt.
-- August 2021: Flashbots Auction Alpha (v0.3) made available for miners and searchers to adopt.
+- July 2021: Flashbots Auction Alpha (v0.3) made available for miners and searchers to adopt.
 - September 2021: Flashbots Auction Alpha (v0.4) made available for miners and searchers to adopt.
 - February 2022: Flashbots Auction Alpha (v0.5) made available for miners and searchers to adopt.
 - February, 2022: Flashbots Auction Alpha (v0.6) made available for miners and searchers to adopt.


### PR DESCRIPTION
Corrected minor error in timeline. V0.3 was released in July not August. 

See info here: https://github.com/flashbots/flashbots-docs/pull/131
