### PR TITLE
docs(security): add bug bounty post mortem

### DIFF
--- a/docs/flashbots-mev-boost/security.md
+++ b/docs/flashbots-mev-boost/security.md
@@ -9,4 +9,8 @@ If you find a security vulnerability on this project or any other initiative rel
 
 ### Bug Bounties
 
-- Coming soon!
+#### Post-mortem for a relay vulnerability leading to proposers falling back to local block production
+
+- On November 10, 2022, a vulnerability in the Flashbots relay was exploited, causing block proposers to fall back to local block production instead of MEV-Boost blocks. The issue stemmed from incorrect `timestamp` and `prev_randao` values in block builder submissions, leading to their rejection by the beacon node. The vulnerability was responsibly disclosed by the [Manifold Finance team](https://twitter.com/foldfinance), and a fix was implemented and deployed by collaborating with various security and engineering teams. The incident affected approximately 350 blocks but did not result in proposers missing slots. 
+
+For more details, ["Post-mortem for a relay vulnerability leading to proposers falling back to local block production (Nov. 10, 2022)"](https://collective.flashbots.net/t/post-mortem-for-a-relay-vulnerability-leading-to-proposers-falling-back-to-local-block-production-nov-10-2022/727)


### PR DESCRIPTION
This pull request updates our documentation to include information about a security incident involving a Flashbots relay vulnerability on November 10, 2022. The vulnerability caused block proposers to fall back to local block production due to incorrect `timestamp` and `prev_randao` values in block builder submissions. The issue was disclosed by the Manifold team and promptly fixed. Approximately 350 blocks were affected, but no slots were missed.