### PR TITLE
fix(docs): correct admonition syntax in quick-start guide

### DIFF
--- a/docs/flashbots-protect/quick-start.mdx
+++ b/docs/flashbots-protect/quick-start.mdx
@@ -28,7 +28,9 @@ Fast mode details:
 
 Wallets and applications can receive customer support for transactions tagged with their `originId`. To opt into customer support update your RPC URL to `rpc.flashbots.net/fast?originId=[your-wallet-name]`.
 
-:::warning Do Not Switch RPCs Before Transaction Confirmation If you submit a transaction through Flashbots Protect via the MetaMask wallet, do not switch RPCs before transaction confirmation. MetaMask may resend the transaction to the public mempool exposing your transaction to potential MEV attacks if RPCs are switched before transaction confirmation.
+:::warning Do Not Switch RPCs Before Transaction Confirmation
+
+If you submit a transaction through Flashbots Protect via the MetaMask wallet, do not switch RPCs before transaction confirmation. MetaMask may resend the transaction to the public mempool exposing your transaction to potential MEV attacks if RPCs are switched before transaction confirmation.
 
 :::
 


### PR DESCRIPTION
The warning about not switching RPCs before transaction confirmation was not properly formatted as an admonition. This commit fixes the syntax to ensure the warning is displayed correctly in the documentation.