### PR TITLE
Explain how to delegate refund recipients in gas fee refund docs

### DIFF
--- a/docs/flashbots-auction/advanced/gas-fee-refunds.md
+++ b/docs/flashbots-auction/advanced/gas-fee-refunds.md
@@ -115,7 +115,7 @@ where $\phi(T, c)$ are the orginal flat-tax rebates as defined above.
 
 ## Who receives refunds
 
-The refund recipient is the signer used on the `eth_sendBundle`, `mev_sendBundle`, or `eth_sendPrivateTransaction` request.
+By default, the refund recipient is the signer used on the `eth_sendBundle`, `mev_sendBundle`, or `eth_sendPrivateTransaction` request. You can delegate your recipient to a different address using the `flashbots_setFeeRefundRecipient` API.
 
 ## How to track refunds
 

--- a/docs/flashbots-auction/advanced/gas-fee-refunds.md
+++ b/docs/flashbots-auction/advanced/gas-fee-refunds.md
@@ -119,6 +119,4 @@ By default, the refund recipient is the signer used on the `eth_sendBundle`, `me
 
 ## How to track refunds
 
-Refunds are tracked from a start date of July 8, 2024. Via an upcoming API, users will be able to:
-* View unclaimed refund amounts
-* Delegate refunds to an Ethereum account other than their signing key address.
+Refunds are tracked from a start date of July 8, 2024. Users will be able to view refund amounts via an upcoming API.

--- a/docs/flashbots-protect/gas-fee-refunds.md
+++ b/docs/flashbots-protect/gas-fee-refunds.md
@@ -44,4 +44,4 @@ For the private transaction API: The refund recipient is the signer used on the 
 
 ## How to track refunds
 
-Refunds are tracked from a start date of July 8, 2024. Users wil be able to view unclaimed refund amounts via an upcoming API.
+Refunds are tracked from a start date of July 8, 2024. Users wil be able to view refund amounts via an upcoming API.


### PR DESCRIPTION
* Add a sentence about the flashbots_setFeeRefundRecipient API in the searcher docs for gas fee refunds. Right now the API is documented but not linked in the main gas fee refunds page.
* Update language around refund API in protect and searcher docs to be consistent with current functionality.