### PR TITLE
set rate limits for bundles `relay.flashbots.net`

### DIFF
--- a/docs/flashbots-protect/additional-documentation/ratelimiting.md
+++ b/docs/flashbots-protect/additional-documentation/ratelimiting.md
@@ -2,16 +2,31 @@
 title: Rate limiting
 ---
 
-In order to protect our service from abuse we have rate limits on the number of requests that can be made to Flashbots Protect RPC. Currently, the rate limits are set as follows:
+In order to protect our service from abuse we have rate limits on the number of requests that can be made. Currently, the rate limits are set as follows.
 
-- There is no rate limit for `eth_sendRawTransaction`
-- `eth_call` 200/IP/5min
-- `eth_getTransactionReceipt` 200/IP/5min
-- `eth_getTransactionByBlockNumberAndIndex` 200/IP/5min
-- `eth_getBalance` 200/IP/5min
-- Other requests are capped to 600/IP/5min
+## `rpc.flashbots.net` - Flashbots Protect RPC
+
+| Method                                     | Limit             |
+|--------------------------------------------|-------------------|
+| `eth_sendRawTransaction`                   | None              |
+| `eth_call`                                 | 200 / IP / 5 min  |
+| `eth_getTransactionReceipt`                | 200 / IP / 5 min  |
+| `eth_getTransactionByBlockNumberAndIndex`  | 200 / IP / 5 min  |
+| `eth_getBalance`                           | 200 / IP / 5 min  |
+| All others                                 | 600 / IP / 5 min  |
 
 Note that this is _requests_ and not _transactions_ submitted per second. There is no limitation on the number of transactions in a request. Note that you are not required to read JSON RPC requests to send transactions to Flashbots Protect RPC.
+
+## `relay.flashbots.net` - Bundles
+
+| Method              | Limit              |
+|---------------------|--------------------|
+| `eth_sendBundle`    | 1800 / IP / 1 min  |
+| `mev_sendBundle`    | 1800 / IP / 1 min  |
+| `eth_cancelBundle`  | 600 / IP / 1 min   |
+| `mev_simBundle`     | 300 / IP / 1 min   |
+| `eth_callBundle`    | 300 / IP / 1 min   |
+| All others          | 120 / IP / 1 min   |
 
 ## Rate limiting exceptions
 

--- a/docs/flashbots-protect/additional-documentation/ratelimiting.md
+++ b/docs/flashbots-protect/additional-documentation/ratelimiting.md
@@ -2,7 +2,7 @@
 title: Rate limiting
 ---
 
-In order to protect our service from abuse we have rate limits on the number of requests that can be made. Currently, the rate limits are set as follows.
+In order to protect our services from abuse we have rate limits on the number of requests that can be made. Currently, the rate limits are set as follows.
 
 ## `rpc.flashbots.net` - Flashbots Protect RPC
 


### PR DESCRIPTION
We're introducing new rate limits for the bundle relay at `relay.flashbots.net`. The Protect RPC is unaffected.

| Method              | Limit              |
|---------------------|--------------------|
| `eth_sendBundle`    | 1800 / IP / 1 min  |
| `mev_sendBundle`    | 1800 / IP / 1 min  |
| `eth_cancelBundle`  | 600 / IP / 1 min   |
| `mev_simBundle`     | 300 / IP / 1 min   |
| `eth_callBundle`    | 300 / IP / 1 min   |
| All others          | 120 / IP / 1 min   |