### PR TITLE
Clarify cancellation format

### DIFF
--- a/docs/flashbots-protect/cancellations.md
+++ b/docs/flashbots-protect/cancellations.md
@@ -8,7 +8,7 @@ Flashbots Protect provides the functionality to cancel pending transactions. To 
 
 - It must be submitted from the **same address** as the original transaction that is intended to be cancelled.
 - It should have the **same nonce** as the original transaction.
-- The **from and to addresses** should match those of the original transaction.
+- The **from and to addresses** should both be set to the **from address** of the original transaction.
 - The **data field** of the cancellation transaction should be left empty.
 
 ## No cost to cancel


### PR DESCRIPTION
The from and to addresses of the cancel tx should be set to the from address of the original tx. Previously the language made it sound like the to address of the cancel tx should be set to the to address of the original tx (this is wrong).